### PR TITLE
D8CORE-355 Use decanter breakpoints in step definition

### DIFF
--- a/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
@@ -41,6 +41,7 @@ class SwsMinkContext extends RawMinkContext {
   public function iSetWindowSize($size) {
     // Sizes are width, height values for the window size.
     $sizes = [
+      'extra small' => [575, 320],
       'small' => [576, 320],
       'medium' => [768, 1024],
       'large' => [992, 768],

--- a/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
@@ -31,6 +31,31 @@ class SwsMinkContext extends RawMinkContext {
   }
 
   /**
+   * Set the window to a breakpoint size.
+   *
+   * @param string $size
+   *   Small, Medium, Large, or 'Extra Large' screen.
+   *
+   * @Then I set window size to :size
+   */
+  public function iSetWindowSize($size) {
+    $sizes = [
+      'small' => [576, 320],
+      'medium' => [768, 1024],
+      'large' => [992, 768],
+      'extra large' => [1500, 800],
+    ];
+
+    $size = strtolower($size);
+    if (array_key_exists($size, $sizes)) {
+      $this->iSetWindowDimensions($sizes[$size][0], $sizes[$size][1]);
+      return;
+    }
+
+    $this->iSetWindowDimensions($sizes['extra large'][0], $sizes['extra large'][1]);
+  }
+
+  /**
    * Change the window dimensions.
    *
    * @param int $width

--- a/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
@@ -39,7 +39,7 @@ class SwsMinkContext extends RawMinkContext {
    * @Then I set the window size to :size
    */
   public function iSetWindowSize($size) {
-    // Sizes are height, width values for the window size.
+    // Sizes are width, height values for the window size.
     $sizes = [
       'small' => [576, 320],
       'medium' => [768, 1024],

--- a/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
@@ -36,7 +36,7 @@ class SwsMinkContext extends RawMinkContext {
    * @param string $size
    *   Small, Medium, Large, or 'Extra Large' screen.
    *
-   * @Then I set window size to :size
+   * @Then I set the window size to :size
    */
   public function iSetWindowSize($size) {
     $sizes = [

--- a/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsMinkContext.php
@@ -39,6 +39,7 @@ class SwsMinkContext extends RawMinkContext {
    * @Then I set the window size to :size
    */
   public function iSetWindowSize($size) {
+    // Sizes are height, width values for the window size.
     $sizes = [
       'small' => [576, 320],
       'medium' => [768, 1024],


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Created step definition for easily switching breakpoints from decanter.

# Needed By (Date)
- End of sprint (8/30)

# Urgency
- low

# Steps to Test
1. checkout https://github.com/SU-SWS/acsf-cardinalsites/pull/16
1. delete `tests/behat/local.yml` file
1. `composer install --prefer-source`
1. `cd vendor/su-sws/stanford-caravan`
1. `git checkout D8CORE-355-decanter-breakpoints`
1. modify a behat to use the format `Then I set the window to "medium"`
1. run the behat test and ensure it doesnt error on that step.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
