### PR TITLE
Allow Latest dev version of Drupal

### DIFF
--- a/src/Robo/Tasks/RoboFile.php
+++ b/src/Robo/Tasks/RoboFile.php
@@ -389,7 +389,7 @@ class RoboFile extends Tasks {
 
     $this->say(sprintf('Getting %s version of Drupal Core', trim($versions[0])));
     $this->taskComposerRequire()
-      ->dir($html_path)
+      ->dir($dir)
       ->arg('drupal/core:' . trim($versions[0]))
       ->option('no-update')
       ->run();

--- a/src/Robo/Tasks/RoboFile.php
+++ b/src/Robo/Tasks/RoboFile.php
@@ -335,6 +335,9 @@ class RoboFile extends Tasks {
     }
     $this->tempFixMink("$html_path/composer.json");
     $this->_deleteDir("$html_path/artifacts");
+    // Delete core directory to avoid update issues since we delete files from
+    // the standard profile later. This also ensure we always get a clean core.
+    $this->_deleteDir("$html_path/web/core");
 
     $extension_type = $this->getExtensionType($extension_dir);
     $extension_name = $this->getExtensionName($extension_dir);

--- a/src/Robo/Tasks/RoboFile.php
+++ b/src/Robo/Tasks/RoboFile.php
@@ -28,10 +28,6 @@ class RoboFile extends Tasks {
     $this->toolDir = dirname(__FILE__, 4);
   }
 
-  public function miketest() {
-    $this->say($this->getLatestDrupalVersion());
-  }
-
   /**
    * Run phpunit tests on the given extension.
    *


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow for `--latest-drupal` flag to test against dev versions of drupal core.

# Need Review By (Date)
- asap, to use this with stanford_media

# Urgency
- low

# Steps to Test
1. review https://circleci.com/gh/SU-SWS/stanford_media/231

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
