### PR TITLE
D8CORE-1479: Add two new step definitions

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# READY FOR REVIEW/NOT READY
+- (Edit the above to reflect status)
+
+# Summary
+- TL;DR - what's this PR for?
+
+# Review By (Date)
+- When does this need to be reviewed by?
+
+# Urgency
+- How critical is this PR?
+
+# Steps to Test
+
+1. Do this
+2. Then this
+3. Then this
+
+# Affected Projects or Products
+- Does this PR impact any particular projects, products, or modules?
+
+# Associated Issues and/or People
+- JIRA ticket
+- Other PRs
+- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
+- Anyone who should be notified? (`@mention` them here)
+
+# See Also
+- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

--- a/src/StanfordBehat/DrupalExtension/Context/SwsContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsContext.php
@@ -8,6 +8,7 @@ use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\DrupalExtension\Context\DrushContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Drupal\Core\Entity\EntityInterface;
+use Exception;
 
 /**
  * FeatureContext class defines custom step definitions for Behat.
@@ -221,5 +222,33 @@ class SwsContext extends RawDrupalContext implements SnippetAcceptingContext {
     }
     $field->setValue($value);
   }
+
+  /**
+   * @Then /^the response header "([^"]*)" should contain "([^"]*)"$/
+   */
+  public function theResponseHeaderShouldContain($arg1, $arg2) {
+    $mink = $this->minkContext;
+    $headers = $mink->getSession()->getResponseHeaders();
+    if (!isset($headers[$arg1])) {
+      throw new Exception('The HTTP header "' . $arg1 . '" does not appear to be set.');
+    }
+    if (!in_array($arg2, $headers[$arg1])) {
+      throw new Exception('The HTTP header "' . $arg1 . '" did not contain "' . $arg2 . '"');
+    }
+  }
+
+  /**
+   * @Then /^the response header should not have "([^"]*)"$/
+   */
+  public function theResponseHeaderShouldNotHave($arg1) {
+    $mink = $this->minkContext;
+    $headers = $mink->getSession()->getResponseHeaders();
+
+    if (isset($headers[$arg1])) {
+      throw new Exception('The HTTP header "' . $arg1 . '" is set to: ' . array_pop($headers[$arg1]) . '.');
+    }
+
+  }
+
 
 }

--- a/src/StanfordBehat/DrupalExtension/Context/SwsContext.php
+++ b/src/StanfordBehat/DrupalExtension/Context/SwsContext.php
@@ -227,8 +227,7 @@ class SwsContext extends RawDrupalContext implements SnippetAcceptingContext {
    * @Then /^the response header "([^"]*)" should contain "([^"]*)"$/
    */
   public function theResponseHeaderShouldContain($arg1, $arg2) {
-    $mink = $this->minkContext;
-    $headers = $mink->getSession()->getResponseHeaders();
+    $headers = $this->getSession()->getResponseHeaders();
     if (!isset($headers[$arg1])) {
       throw new Exception('The HTTP header "' . $arg1 . '" does not appear to be set.');
     }
@@ -241,8 +240,7 @@ class SwsContext extends RawDrupalContext implements SnippetAcceptingContext {
    * @Then /^the response header should not have "([^"]*)"$/
    */
   public function theResponseHeaderShouldNotHave($arg1) {
-    $mink = $this->minkContext;
-    $headers = $mink->getSession()->getResponseHeaders();
+    $headers = $this->getSession()->getResponseHeaders();
 
     if (isset($headers[$arg1])) {
       throw new Exception('The HTTP header "' . $arg1 . '" is set to: ' . array_pop($headers[$arg1]) . '.');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add two new step definitions
- Add Github templates

# Needed By (Date)
- This is needed before https://github.com/SU-SWS/acsf-cardinalsites/pull/97

# Criticality
- How critical is this PR on a 1-10 scale? 5/10
- Prerequisite for blocking bad actors

# Steps to Test

1. See https://github.com/SU-SWS/acsf-cardinalsites/pull/97
2. See [CircleCI results](https://circleci.com/gh/SU-SWS/acsf-cardinalsites/2463?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

# Affected Projects or Products
- CardinalSites, and eventually LelandD8

# Associated Issues and/or People
- JIRA ticket: D8CORE-1479
- Other PRs: https://github.com/SU-SWS/acsf-cardinalsites/pull/97

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)