### PR TITLE
Added option to specify main branch

### DIFF
--- a/src/Robo/Tasks/RoboFile.php
+++ b/src/Robo/Tasks/RoboFile.php
@@ -61,7 +61,7 @@ class RoboFile extends Tasks {
    * @usage vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
    * @usage vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY} main
    */
-  public function backToDev($old_semver, $directory, $main_branch='master') {
+  public function backToDev($old_semver, $directory, $main_branch = 'master') {
     $this->setGlobalGitConfigs();
 
     list($major, $minor, $point) = explode('.', $old_semver);


### PR DESCRIPTION


# READY FOR REVIEW

# Summary

Added an optional parameter to the back-to-dev command, allowing you to specify the main branch of the repo, for use in cases where the `master` branch is actually called `main`, for instance.

# Review By (Date)
- 🤷 

# Urgency
- We've gotten by without it so far.

# Steps to Test

1. Do a release as normal; verify the back-to-dev step works as expected.
2. Do a release in a module where the `master` branch has been renamed `main`
	- You will need to update the .circleci/config.yml file so that the back-to-dev job reads like so: ` ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY} main`
	- verify the back-to-dev job does what you expect.
